### PR TITLE
Handle MSG_INFO as a command response

### DIFF
--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -219,6 +219,8 @@ class Connection(object):
         elif response[0] == MSG_ERROR:
             exception, string = handle_error(response[1:])
             raise exception(string)
+        elif response[0] == MSG_INFO:
+            logger.info("%s" % (response[1:]))
         elif self.language == 'control' and not self.hostname:
             if response.startswith("OK"):
                 return response[2:].strip() or ""


### PR DESCRIPTION
The server might respond with comments (lines starting with the char
'#') after a command. This is very useful for debugging. Use the logger
to capture these messages exactly as is done in the login case.