### PR TITLE
Multiline handling

### DIFF
--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -224,7 +224,7 @@ class Connection(object):
         if response[:2] == MSG_QUPDATE:
             lines = response.split('\n')
             if any([l.startswith(MSG_ERROR) for l in lines]):
-                index = next(i for i,v in enumerate(lines) if v.startswith(MSG_ERROR))
+                index = next(i for i, v in enumerate(lines) if v.startswith(MSG_ERROR))
                 exception, string = handle_error(lines[index][1:])
                 raise exception(string)
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,3 +5,4 @@ tox
 nose
 Sphinx
 sphinx_rtd_theme
+mock

--- a/test/test_multiline.py
+++ b/test/test_multiline.py
@@ -45,5 +45,4 @@ class MultilineResponseTest(unittest.TestCase):
         c.state = pymonetdb.mapi.STATE_READY
 
         # Make sure that cmd raises the correct exception
-        with self.assertRaises(pymonetdb.IntegrityError):
-            resp = c.cmd(query_text)
+        self.assertRaises(pymonetdb.IntegrityError, c.cmd, [query_text])

--- a/test/test_multiline.py
+++ b/test/test_multiline.py
@@ -1,0 +1,49 @@
+import unittest
+from mock import patch
+import pymonetdb
+
+class MultilineResponseTest(unittest.TestCase):
+    """MonetDB sometimes sends back multi-line responses. Most notably when there
+       are more than one concurrent update transactions due to the Optimistic
+       Concurrency Control that MonetDB is implementing, only one of them will
+       succeed. In auto-commit mode the failed transactions will get something
+       like the following response:
+
+       &2 1 -1\n!4000!COMMIT: transaction is aborted because of concurrency conflicts, will ROLLBACK instead\n
+
+       The first line is emitted by the MonetDB server when the update is
+       actually executed inside the MAL plan while the second is emitted
+       outside the MAL plan during the commit that fails. We should take this
+       into account.
+
+       Another case is comments that start with the '#' char and should be
+       ignored. These are useful for debugging the server.
+
+       This class is intended to create a test suite for this kind of cases.
+       Since there is no deterministic way of forcing transaction failure, the
+       MonetDB server will be mocked using https://pypi.python.org/pypi/mock
+
+    """
+
+    @patch('pymonetdb.mapi.Connection._putblock')
+    @patch('pymonetdb.mapi.Connection._getblock')
+    def test_failed_transactions(self, mock_getblock, mock_putblock):
+        """This test is mocking 2 low level methods in the mapi.Connection class:
+           mapi.Connection._getblock
+           mapi.Connection._putblock
+
+           and tests mapi.Connection.cmd. Specifically we test for the event
+           that a transaction has failed due to concurrency conflicts.
+        """
+        query_text = 'sINSERT INTO tbl VALUES (1)'
+        response = "&2 1 -1\n!40000!COMMIT: transaction is aborted because of concurrency conflicts, will ROLLBACK instead\n"
+        error_message = "40000!COMMIT: transaction is aborted because of concurrency conflicts, will ROLLBACK instead"
+        mock_getblock.return_value = response
+        c = pymonetdb.mapi.Connection()
+
+        # Simulate a connection
+        c.state = pymonetdb.mapi.STATE_READY
+
+        # Make sure that cmd raises the correct exception
+        with self.assertRaises(pymonetdb.IntegrityError):
+            resp = c.cmd(query_text)

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py26,py27,py34,pypy
 deps=
     pytest
     six
+    mock
 commands=py.test
 
 passenv=MAPIPORT TSTHOSTNAME TSTPASSPHRASE TSTDB TSTUSERNAME TSTPASSWORD


### PR DESCRIPTION
This PR includes a test suite that mocks connections to MonetDB in order to test parts of the pymonetdb module. The first test in it mocks `mapi.Connection._putblock` and `mapi.Connection._getblock`, in order to test multi line responses from the server. 

Also this PR adds support for the case of failed transactions in auto-commit mode.
