### PR TITLE
fix cutoff long packets with utf-8 characters

### DIFF
--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -328,8 +328,9 @@ class Connection(object):
     def _putblock_inet(self, block):
         pos = 0
         last = 0
+        block = encode(block)
         while not last:
-            data = encode(block[pos:pos + MAX_PACKAGE_LENGTH])
+            data = block[pos:pos + MAX_PACKAGE_LENGTH]
             length = len(data)
             if length < MAX_PACKAGE_LENGTH:
                 last = 1


### PR DESCRIPTION
In python3 encode was applied after after splicing the string. With encode, utf-8 characters are potentially expanded to multiple octets. For a given block that exceeded MAX_PACKAGE_LENGTH this resulted in the
last few octets falling off a package. 
