### PR TITLE
In python3 next has been renamed to __next__

### DIFF
--- a/pymonetdb/sql/cursors.py
+++ b/pymonetdb/sql/cursors.py
@@ -320,6 +320,9 @@ class Cursor(object):
             raise StopIteration
         return row
 
+    def __next__(self):
+        return self.next()
+
     def __store_result(self, block):
         """ parses the mapi result into a resultset"""
 

--- a/test/test_dbapi2.py
+++ b/test/test_dbapi2.py
@@ -570,6 +570,28 @@ class DatabaseAPI20Test(unittest.TestCase):
             ]
         return populate
 
+
+
+    def test_cursor_next(self):
+        con = self._connect()
+        try:
+            cur = con.cursor()
+
+            self.executeDDL1(cur)
+            for sql in self._populate():
+                cur.execute(sql)
+
+            cur.execute('select name from %sbooze' % self.table_prefix)
+
+            for row in cur:
+                pass
+
+        except TypeError:
+            self.fail("Cursor iterator not implemented correctly")
+
+        finally:
+            con.close()
+
     def test_fetchmany(self):
         con = self._connect()
         try:


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-3114/

Without this change
```python
for row in cursor:
    etc
```

would give an error
```
 TypeError: iter() returned non-iterator of type 'Cursor'
```

