### PR TITLE
Queries ending with comments fail to execute

### DIFF
--- a/pymonetdb/sql/connections.py
+++ b/pymonetdb/sql/connections.py
@@ -130,7 +130,7 @@ class Connection(object):
 
     def execute(self, query):
         """ use this for executing SQL queries """
-        return self.command('s' + query + ';')
+        return self.command('s' + query + '\n;')
 
     def command(self, command):
         """ use this function to send low level mapi commands """

--- a/test/test_dbapi2.py
+++ b/test/test_dbapi2.py
@@ -1014,3 +1014,13 @@ class DatabaseAPI20Test(unittest.TestCase):
             encoded = unicode(input, 'utf-8')
         self.assertEqual(returned, encoded)
         self.assertEqual(type(returned), text_type)
+
+    def test_query_ending_with_comment(self):
+        con = self._connect()
+        cur = con.cursor()
+        self.executeDDL1(cur)
+        cur.execute("insert into %sbooze values ('foo')" % self.table_prefix)
+        cur.execute('select * from %sbooze --This is a SQL comment' % self.table_prefix)
+        # the above line should execute without problems
+        self.assertEqual(1, cur.rowcount,
+                         'queries ending in comments should be executed correctly')


### PR DESCRIPTION
If the user ends a query with a comment, the query is not executed.

This PR adds a test and the fix.