### PR TITLE
add timeout for server connection

### DIFF
--- a/pymonetdb/control.py
+++ b/pymonetdb/control.py
@@ -70,7 +70,7 @@ class Control:
     stop, lock, unlock, destroy your databases and request status information.
     """
     def __init__(self, hostname=None, port=50000, passphrase=None,
-                 unix_socket=None):
+                 unix_socket=None, connect_timeout=-1):
 
         if not unix_socket:
             unix_socket = "/tmp/.s.merovingian.%i" % port
@@ -83,19 +83,22 @@ class Control:
         self.port = port
         self.passphrase = passphrase
         self.unix_socket = unix_socket
+        self.connect_timeout = connect_timeout
 
         # check connection
         self.server.connect(hostname=hostname, port=port, username='monetdb',
                             password=passphrase,
                             database='merovingian', language='control',
-                            unix_socket=unix_socket)
+                            unix_socket=unix_socket,
+                            connect_timeout=connect_timeout)
         self.server.disconnect()
 
     def _send_command(self, database_name, command):
         self.server.connect(hostname=self.hostname, port=self.port,
                             username='monetdb', password=self.passphrase,
                             database='merovingian', language='control',
-                            unix_socket=self.unix_socket)
+                            unix_socket=self.unix_socket,
+                            connect_timeout=self.connect_timeout)
         try:
             return self.server.cmd("%s %s\n" % (database_name, command))
         finally:

--- a/pymonetdb/sql/connections.py
+++ b/pymonetdb/sql/connections.py
@@ -20,7 +20,7 @@ class Connection(object):
 
     def __init__(self, database, hostname=None, port=50000, username="monetdb",
                  password="monetdb", unix_socket=None, autocommit=False,
-                 host=None, user=None):
+                 host=None, user=None, connect_timeout=-1):
         """ Set up a connection to a MonetDB SQL database.
 
         args:
@@ -32,6 +32,8 @@ class Connection(object):
             unix_socket (str): socket to connect to. used when hostname not set
                                 (default: "/tmp/.s.monetdb.50000")
             autocommit (bool):  enable/disable auto commit (default: False)
+            connect_timeout -- the socket timeout while connecting
+                               (default: see python socket module)
 
         returns:
             Connection object
@@ -50,7 +52,7 @@ class Connection(object):
         self.mapi = mapi.Connection()
         self.mapi.connect(hostname=hostname, port=int(port), username=username,
                           password=password, database=database, language="sql",
-                          unix_socket=unix_socket)
+                          unix_socket=unix_socket, connect_timeout=connect_timeout)
         self.set_autocommit(autocommit)
         self.set_sizeheader(True)
         self.set_replysize(100)


### PR DESCRIPTION
This PR allows to configure the socket timeout when connecting the monetdb server,
for both `sql.Connection` and `Control`.

Currently, a timeout can be set only once the connection is already established.