### PR TITLE
Fix replysize being None and unnecessary property sets.

### DIFF
--- a/pymonetdb/sql/connections.py
+++ b/pymonetdb/sql/connections.py
@@ -55,12 +55,7 @@ class Connection(object):
                           unix_socket=unix_socket, connect_timeout=connect_timeout)
         self.set_autocommit(autocommit)
         self.set_sizeheader(True)
-
         self.set_replysize(100)
-
-        self.autocommit = autocommit
-        self.sizeheader = True
-        self.replysize = None
 
     def close(self):
         """ Close the connection.


### PR DESCRIPTION
It looks like some extra property sets were committed as part of https://github.com/gijzelaerr/pymonetdb/commit/394174591add894da5a7a20535849679053f05db.

replysize=None can get propagated to Cursor.arraysize and in some cases causes an exception:

```
  File "pymonetdb/pymonetdb/sql/cursors.py", line 538, in nextset
    end = min(self.rowcount, self.rownumber + self.arraysize)
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```