### PR TITLE
Correctly monetize python datetime, date, time and timedelta types an…

### DIFF
--- a/pymonetdb/sql/monetize.py
+++ b/pymonetdb/sql/monetize.py
@@ -47,6 +47,34 @@ def monet_bytes(data):
     return monet_escape(data)
 
 
+def monet_datetime(data):
+    """
+    returns a casted timestamp
+    """
+    return "TIMESTAMP %s" % monet_escape(data)
+
+
+def monet_date(data):
+    """
+    returns a casted date
+    """
+    return "DATE %s" % monet_escape(data)
+
+
+def monet_time(data):
+    """
+    returns a casted time
+    """
+    return "TIME %s" % monet_escape(data)
+
+
+def monet_timedelta(data):
+    """
+    returns timedelta casted to interval seconds
+    """
+    return "INTERVAL %s SECOND" % monet_escape(int(data.total_seconds()))
+
+
 def monet_unicode(data):
     return monet_escape(data.encode('utf-8'))
 
@@ -58,10 +86,10 @@ mapping = [
     (complex, str),
     (float, str),
     (decimal.Decimal, str),
-    (datetime.datetime, monet_escape),
-    (datetime.time, monet_escape),
-    (datetime.date, monet_escape),
-    (datetime.timedelta, monet_escape),
+    (datetime.datetime, monet_datetime),
+    (datetime.time, monet_time),
+    (datetime.date, monet_date),
+    (datetime.timedelta, monet_timedelta),
     (bool, monet_bool),
     (type(None), monet_none),
 ]

--- a/test/test_capabilities.py
+++ b/test/test_capabilities.py
@@ -12,6 +12,7 @@
     Adapted from a script by M-A Lemburg and taken from the MySQL python driver.
 
 """
+import datetime
 import os
 from time import time
 import unittest
@@ -420,6 +421,23 @@ class DatabaseTest(unittest.TestCase):
             code = f.read()
             self.assertEqual('test_python_udf(i)' in code, True)
 
+    def test_temporal_operations(self):
+        dt = datetime.datetime(2017, 12, 6, 12, 30)
+        self.cursor.execute("SELECT %(dt)s - INTERVAL '1' DAY", {'dt': dt})
+        expected = datetime.datetime(2017, 12, 5, 12, 30)
+        self.assertEqual(self.cursor.fetchone()[0], expected)
 
+        d = datetime.date(2017, 12, 6)
+        self.cursor.execute("SELECT %(d)s - INTERVAL '1' DAY", {'d': d})
+        expected = datetime.date(2017, 12, 5)
+        self.assertEqual(self.cursor.fetchone()[0], expected)
 
+        t = datetime.time(12, 5)
+        self.cursor.execute("SELECT %(t)s - INTERVAL '30' MINUTE", {'t': t})
+        expected = datetime.time(11, 35)
+        self.assertEqual(self.cursor.fetchone()[0], expected)
 
+        td = datetime.timedelta(days=5, hours=2, minutes=10)
+        self.cursor.execute("SELECT %(dt)s - %(td)s", {'dt': dt, 'td': td})
+        expected = datetime.datetime(2017, 12, 1, 10, 20)
+        self.assertEqual(self.cursor.fetchone()[0], expected)

--- a/test/test_monetize.py
+++ b/test/test_monetize.py
@@ -4,6 +4,7 @@
 #
 # Copyright 1997 - July 2008 CWI, August 2008 - 2016 MonetDB B.V.
 
+import datetime
 import unittest
 from pymonetdb.sql.monetize import convert, monet_escape
 from pymonetdb.exceptions import ProgrammingError
@@ -23,3 +24,19 @@ class TestMonetize(unittest.TestCase):
             pass
         x = Unknown()
         self.assertRaises(ProgrammingError, convert, x)
+
+    def test_datetime(self):
+        x = datetime.datetime(2017, 12, 6, 12, 30)
+        self.assertEqual(convert(x), "TIMESTAMP '2017-12-06 12:30:00'")
+
+    def test_date(self):
+        x = datetime.date(2017, 12, 6)
+        self.assertEqual(convert(x), "DATE '2017-12-06'")
+
+    def test_time(self):
+        x = datetime.time(12, 5)
+        self.assertEqual(convert(x), "TIME '12:05:00'")
+
+    def test_timedelta(self):
+        x = datetime.timedelta(days=5, hours=2, minutes=10)
+        self.assertEqual(convert(x), "INTERVAL '439800' SECOND")


### PR DESCRIPTION
…d add tests.

This makes the following work, for example:
```python
dt = datetime.datetime(2017, 12, 6, 12, 30)
td = datetime.timedelta(days=5, hours=2, minutes=10)
cursor.execute("SELECT %(dt)s - %(td)s", {'dt': dt, 'td': td})
```