### PR TITLE
Enable TCP_KEEPALIVE to keep consistent with stream.c

### DIFF
--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -138,7 +138,7 @@ class Connection(object):
         if hostname:
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             # For performance, mirror MonetDB/src/common/stream.c socket settings.
-            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 0)
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
             self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.socket.settimeout(self.connect_timeout)
             self.socket.connect((hostname, port))


### PR DESCRIPTION
In stream.c, TCP keepalive is enabled. But it is not in client side. When client is running in docker swarm, long idle is broken by docker swarm and pymonetdb client can not detect broken connection.