### PR TITLE
Fix support for OID type

### DIFF
--- a/pymonetdb/sql/pythonize.py
+++ b/pymonetdb/sql/pythonize.py
@@ -94,6 +94,14 @@ def py_timestamptz(data):
         return datetime.datetime.strptime(dt, '%Y-%m-%d %H:%M:%S') + timezone_delta
 
 
+def oid(data):
+    """represents an object identifier
+
+    For now we will just return the string representation just like mclient does.
+    """
+    return oid
+
+
 mapping = {
     types.CHAR: strip,
     types.VARCHAR: strip,
@@ -108,7 +116,7 @@ mapping = {
     types.SHORTINT: int,
     types.MEDIUMINT: int,
     types.LONGINT: int,
-    types.OID: int,
+    types.OID: oid,
     types.WRD: int,
     types.REAL: float,
     types.FLOAT: float,

--- a/tests/test_oid.py
+++ b/tests/test_oid.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+from pymonetdb import connect
+from tests.util import test_args
+
+
+class TestOid(TestCase):
+    def setUp(self):
+        self.connection = connect(autocommit=False, **test_args)
+        self.cursor = self.connection.cursor()
+
+    def test_oid(self):
+        q = "select tag from sys.queue()"
+        self.cursor.execute(q)
+        rows = self.cursor.fetchall()

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -171,5 +171,6 @@ class TestUnicode(unittest.TestCase):
         self.assertEqual(1, cur.rowcount,
                          'queries ending in comments should be executed correctly')
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For now we will just return the string representation, just like mclient does.