### PR TITLE
Change logger.warn to logger.debug

### DIFF
--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -145,13 +145,13 @@ class Connection(object):
                     self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
                     self.socket.settimeout(self.connect_timeout)
                 except socket.error as msg:
-                    logger.warn(msg)
+                    logger.debug(msg)
                     self.socket = None
                     continue
                 try:
                     self.socket.connect(sa)
                 except socket.error as msg:
-                    logger.warn(msg.strerror)
+                    logger.debug(msg.strerror)
                     self.socket.close()
                     self.socket = None
                     continue


### PR DESCRIPTION
Printing on stderr (or stdin) causes every test written in python in the MonetDB
test suite to fail.