### PR TITLE
Fix blob handling

### DIFF
--- a/pymonetdb/sql/monetize.py
+++ b/pymonetdb/sql/monetize.py
@@ -43,7 +43,7 @@ def monet_bytes(data):
     """
     converts bytes to string
     """
-    return monet_escape(data)
+    return "'%s'" % data.hex()
 
 
 def monet_datetime(data):

--- a/pymonetdb/sql/pythonize.py
+++ b/pymonetdb/sql/pythonize.py
@@ -90,6 +90,11 @@ def py_timestamptz(data):
         return datetime.datetime.strptime(dt, '%Y-%m-%d %H:%M:%S') + timezone_delta
 
 
+def py_bytes(data):
+    """Returns a bytes (py3) or string (py2) object representing the input blob."""
+    return Binary(data)
+
+
 def oid(data):
     """represents an object identifier
 
@@ -102,7 +107,7 @@ mapping = {
     types.CHAR: strip,
     types.VARCHAR: strip,
     types.CLOB: strip,
-    types.BLOB: str,
+    types.BLOB: py_bytes,
     types.TINYINT: int,
     types.SMALLINT: int,
     types.INT: int,
@@ -154,8 +159,7 @@ def convert(data, type_code):
 
 def Binary(data):
     """returns binary encoding of data"""
-    return ''.join(["%02X" % ord(i) for i in str(data)])
-
+    return bytes.fromhex(data)
 
 def DateFromTicks(ticks):
     """Convert ticks to python Date"""

--- a/pymonetdb/sql/pythonize.py
+++ b/pymonetdb/sql/pythonize.py
@@ -161,6 +161,7 @@ def Binary(data):
     """returns binary encoding of data"""
     return bytes.fromhex(data)
 
+
 def DateFromTicks(ticks):
     """Convert ticks to python Date"""
     return Date(*time.localtime(ticks)[:3])

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -18,7 +18,6 @@ import unittest
 from pymonetdb.exceptions import ProgrammingError
 import pymonetdb
 from pymonetdb.sql import monetize
-
 from tests.util import test_args
 
 
@@ -33,7 +32,7 @@ class DatabaseTest(unittest.TestCase):
         self.connection = db
         self.cursor = db.cursor()
         self.BLOBText = ''.join([chr(i) for i in range(33, 127)] * 100)
-        self.BLOBBinary = pymonetdb.Binary(''.join([chr(i) for i in range(256)] * 16))
+        self.BLOBBinary = bytes(range(256))*16
         self.BLOBUText = ''.join([chr(i) for i in range(1, 16384)])
 
     def tearDown(self):

--- a/tests/test_dbapi2.py
+++ b/tests/test_dbapi2.py
@@ -713,8 +713,8 @@ class DatabaseAPI20Test(unittest.TestCase):
         self.assertEqual(str(t1), str(t2))
 
     def test_Binary(self):
-        b = pymonetdb.Binary(b'Something')
-        b = pymonetdb.Binary(b'')
+        b = pymonetdb.Binary('1234567890ABCDEF')
+        b = pymonetdb.Binary('')
 
     def test_STRING(self):
         self.failUnless(hasattr(pymonetdb, 'STRING'),

--- a/tests/test_pythonize.py
+++ b/tests/test_pythonize.py
@@ -10,12 +10,13 @@ import pymonetdb.sql.pythonize
 
 class TestPythonize(unittest.TestCase):
     def test_Binary(self):
-        input1 = ''.join([chr(i) for i in range(256)])
-        output1 = ''.join(["%02X" % i for i in range(256)])
+        input1 = bytes(range(256)).hex()
+        output1 = bytes(range(256))
         result1 = pymonetdb.sql.pythonize.Binary(input1)
         self.assertEqual(output1, result1)
 
-        input2 = '\tdharma'
-        output2 = '09646861726D61'
+        input2 = b'\tdharma'.hex()
+        output2 = b'\tdharma'
+
         result2 = pymonetdb.sql.pythonize.Binary(input2)
         self.assertEqual(output2, result2)

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -58,7 +58,7 @@ class TestUnicode(unittest.TestCase):
         cursor = con.cursor()
         self.executeDDL1(cursor)
         x = u"ô  ’a élé.«S’ilît… de-mun»"
-        cursor.execute(u'insert into %sbooze VALUES (\'%s\')' % (self.table_prefix, x))
+        cursor.execute("insert into %sbooze VALUES ('%s')" % (self.table_prefix, x))
         cursor.execute('select name from %sbooze' % self.table_prefix)
         self.assertEqual(x, cursor.fetchone()[0])
 


### PR DESCRIPTION
This PR implements storing and retrieving Python 3 bytes objects as MonetDB blobs:

```python
import pymonetdb

c = pymonetdb.connect("demo", user="monetdb", password="monetdb", host="monet")
c.set_autocommit(True)
cc = c.cursor()
x = b'binary data'
cc.execute("drop table if exists tbl")
cc.execute("create table tbl(b blob)")
cc.execute("insert into tbl values (%s)", [x])
cc.execute("select * from tbl")
y = cc.fetchall()[0][0]
assert(x == y)
```

