### PR TITLE
Use new MAPI handshake options, if available

### DIFF
--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -304,8 +304,7 @@ class Connection(object):
             raise NotSupportedError("Unsupported hash algorithms required"
                                     " for login: %s" % hashes)
 
-        response = ":".join(["BIG", self.username, pwhash, self.language,
-                         self.database]) + ":"
+        response = ":".join(["BIG", self.username, pwhash, self.language, self.database]) + ":"
 
         if len(challenges) >= 7:
             options_level = 0
@@ -399,6 +398,7 @@ class Connection(object):
         """
 
         self.cmd("Xreply_size %s" % size)
+
 
 class HandshakeOption:
     """

--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -91,10 +91,11 @@ class Connection(object):
         self.password = ""
         self.database = ""
         self.language = ""
+        self.handshake_options = None
         self.connect_timeout = socket.getdefaulttimeout()
 
     def connect(self, database, username, password, language, hostname=None,
-                port=None, unix_socket=None, connect_timeout=-1):
+                port=None, unix_socket=None, connect_timeout=-1, handshake_options=None):
         """ setup connection to MAPI server
 
         unix_socket is used if hostname is not defined.
@@ -120,7 +121,10 @@ class Connection(object):
         self.database = database
         self.language = language
         self.unix_socket = unix_socket
-
+        if handshake_options:
+            self.handshake_options = [opt for opt in handshake_options]
+        else:
+            self.handshake_options = []
         if hostname:
             if self.socket:
                 self.socket.close()
@@ -265,7 +269,12 @@ class Connection(object):
 
     def _challenge_response(self, challenge):
         """ generate a response to a mapi login challenge """
+
         challenges = challenge.split(':')
+        if challenges[-1] != '' or len(challenges) < 7:
+            raise OperationalError("Server sent invalid challenge")
+        challenges.pop()
+
         salt, identity, protocol, hashes, endian = challenges[:5]
         password = self.password
 
@@ -295,8 +304,25 @@ class Connection(object):
             raise NotSupportedError("Unsupported hash algorithms required"
                                     " for login: %s" % hashes)
 
-        return ":".join(["BIG", self.username, pwhash, self.language,
+        response = ":".join(["BIG", self.username, pwhash, self.language,
                          self.database]) + ":"
+
+        if len(challenges) >= 7:
+            options_level = 0
+            for part in challenges[6].split(","):
+                if part.startswith("sql="):
+                    try:
+                        options_level = int(part[4:])
+                    except ValueError:
+                        raise OperationalError("invalid sql options level in server challenge: " + part)
+            options = []
+            for opt in self.handshake_options:
+                if opt.level < options_level:
+                    options.append(opt.name + "=" + str(int(opt.value)))
+                    opt.sent = True
+            response += ",".join(options) + ":"
+
+        return response
 
     def _getblock(self):
         """ read one mapi encoded block """
@@ -373,3 +399,20 @@ class Connection(object):
         """
 
         self.cmd("Xreply_size %s" % size)
+
+class HandshakeOption:
+    """
+    Option that can be set during the MAPI handshake
+
+    Should be sent as <name>=<val>, where <val> is `value` converted to int.
+    The `level` is used to determine if the server supports this option.
+    The `fallback` is a function-like object that can be called with the
+    value (not converted to an integer) as a parameter.
+    Field `sent` can be used to keep track of whether the option has been sent.
+    """
+    def __init__(self, level, name, fallback, value):
+        self.level = level
+        self.name = name
+        self.value = value
+        self.fallback = fallback
+        self.sent = False

--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -121,10 +121,7 @@ class Connection(object):
         self.database = database
         self.language = language
         self.unix_socket = unix_socket
-        if handshake_options:
-            self.handshake_options = [opt for opt in handshake_options]
-        else:
-            self.handshake_options = []
+        self.handshake_options = handshake_options or []
         if hostname:
             if self.socket:
                 self.socket.close()
@@ -400,6 +397,7 @@ class Connection(object):
         self.cmd("Xreply_size %s" % size)
 
 
+# When all supported Python versions support it we can enable @dataclass here.
 class HandshakeOption:
     """
     Option that can be set during the MAPI handshake

--- a/pymonetdb/sql/connections.py
+++ b/pymonetdb/sql/connections.py
@@ -53,14 +53,22 @@ class Connection(object):
         if platform.system() == "Windows" and not hostname:
             hostname = "localhost"
 
+        # level numbers taken from mapi.h
+        handshake_options = [
+            mapi.HandshakeOption(1, "auto_commit", self.set_autocommit, autocommit),
+            mapi.HandshakeOption(2, "reply_size", self.set_replysize, 100),
+            mapi.HandshakeOption(3, "size_header", self.set_sizeheader, True),
+        ]
+
         self.mapi = mapi.Connection()
         self.mapi.connect(hostname=hostname, port=int(port), username=username,
                           password=password, database=database, language="sql",
-                          unix_socket=unix_socket, connect_timeout=connect_timeout)
+                          unix_socket=unix_socket, connect_timeout=connect_timeout,
+                          handshake_options=handshake_options)
 
-        self.set_autocommit(autocommit)
-        self.set_sizeheader(True)
-        self.set_replysize(100)
+        for option in handshake_options:
+            if not option.sent:
+                option.fallback(option.value)
 
     def close(self):
         """ Close the connection.

--- a/pymonetdb/sql/connections.py
+++ b/pymonetdb/sql/connections.py
@@ -53,7 +53,8 @@ class Connection(object):
         if platform.system() == "Windows" and not hostname:
             hostname = "localhost"
 
-        # level numbers taken from mapi.h
+        # Level numbers taken from mapi.h.
+        # The options start out with member .sent set to False.
         handshake_options = [
             mapi.HandshakeOption(1, "auto_commit", self.set_autocommit, autocommit),
             mapi.HandshakeOption(2, "reply_size", self.set_replysize, 100),
@@ -66,6 +67,9 @@ class Connection(object):
                           unix_socket=unix_socket, connect_timeout=connect_timeout,
                           handshake_options=handshake_options)
 
+        # self.mapi.connect() has set .sent to True for all items that
+        # have already been arranged during the initial challenge/response.
+        # Now take care of the rest.
         for option in handshake_options:
             if not option.sent:
                 option.fallback(option.value)


### PR DESCRIPTION
On the default branch you can pass options like auto commit, reply size and time zone directly in the authentication response, without having to round-trip several separate commands to set them. This improves startup time.

The change is backward compatible, the mechanism is only used if the server announces support for it.