### PR TITLE
Allow to connect using a full mapi uri in place of the database parameter.

### DIFF
--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -123,7 +123,7 @@ class Connection(object):
                 unix_socket = parsed.path or unix_socket
                 username = parsed.username or username
                 password = parsed.password or password
-                database='' # must be set in uri parameter
+                database = ''  # must be set in uri parameter
             # parse uri parameters
             if parsed.query:
                 parms = parse_qs(parsed.query)

--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -15,6 +15,7 @@ import hashlib
 import os
 from typing import Optional
 from io import BytesIO
+from urllib.parse import urlparse, parse_qs
 
 from pymonetdb.exceptions import OperationalError, DatabaseError, \
     ProgrammingError, NotSupportedError, IntegrityError
@@ -100,6 +101,38 @@ class Connection(object):
 
         unix_socket is used if hostname is not defined.
         """
+
+        if ':' in database:
+            if not database.startswith('mapi:monetdb:'):
+                raise DatabaseError("colon not allowed in database name, except as part of mapi:monetdb://<hostname>[:<port>]/<database> URI")
+            parsed = urlparse(database[5:])
+            # parse basic settings
+            if parsed.hostname or parsed.port:
+                # connect over tcp
+                if not parsed.path.startswith('/'):
+                    raise DatabaseError('invalid mapi url')
+                database = parsed.path[1:]
+                if '/' in database:
+                    raise DatabaseError('invalid mapi url')
+                username = parsed.username or username
+                password = parsed.password or password
+                hostname = parsed.hostname or hostname
+                port = parsed.port or port
+            else:
+                # connect over unix domain socket
+                unix_socket = parsed.path or unix_socket
+                username = parsed.username or username
+                password = parsed.password or password
+                database='' # must be set in uri parameter
+            # parse uri parameters
+            if parsed.query:
+                parms = parse_qs(parsed.query)
+                if 'database' in parms:
+                    if database == '':
+                        database = parms['database'][-1]
+                    else:
+                        raise DatabaseError('database= query parameter is only allowed with unix domain sockets')
+                # Future work: parse other parameters such as reply_size.
 
         if hostname and hostname[:1] == '/' and not unix_socket:
             unix_socket = '%s/.s.monetdb.%d' % (hostname, port)

--- a/pymonetdb/sql/connections.py
+++ b/pymonetdb/sql/connections.py
@@ -24,7 +24,7 @@ class Connection(object):
         """ Set up a connection to a MonetDB SQL database.
 
         args:
-            database (str): name of the database
+            database (str): name of the database, or MAPI URI
             hostname (str): Hostname where monetDB is running
             port (int): port to connect to (default: 50000)
             username (str): username for connection (default: "monetdb")
@@ -34,6 +34,10 @@ class Connection(object):
             autocommit (bool):  enable/disable auto commit (default: False)
             connect_timeout -- the socket timeout while connecting
                                (default: see python socket module)
+
+        MAPI URI:
+            tcp socket:         mapi:monetdb://[<username>[:<password>]@]<host>[:<port>]/<database>
+            unix domain socket: mapi:monetdb:///[<username>[:<password>]@]path/to/socket?database=<database>
 
         returns:
             Connection object

--- a/tests/test_mapi_uri.py
+++ b/tests/test_mapi_uri.py
@@ -1,0 +1,69 @@
+import os
+from pymonetdb.exceptions import DatabaseError
+from socket import gethostbyname
+from unittest import TestCase
+from pymonetdb import connect
+from tests.util import test_args
+
+class TestMapiUri(TestCase):
+
+    def setUp(self):
+        self.hostname = test_args['hostname']
+        self.port = test_args['port']
+        self.database = test_args['database']
+        self.username = test_args['username']
+        self.password = test_args['password']
+
+    def attempt_connect(self, uri, username=None, password=None):
+        args = dict(database=uri)
+        if username:
+            args['username'] = username
+        if password:
+            args['password'] = password
+        connection = connect(autocommit=False, **args)
+        cursor = connection.cursor()
+        q = "select tag from sys.queue()"
+        cursor.execute(q)
+        rows = cursor.fetchall()
+
+    def test_no_uri(self):
+        # test setUp and attempt_connect themselves
+        self.attempt_connect(self.database, username=self.username, password=self.password)
+
+    def test_full_mapi_uri(self):
+        self.attempt_connect(f"mapi:monetdb://{self.hostname}:{self.port}/{self.database}", username=self.username, password=self.password)
+
+    def test_without_port(self):
+        self.attempt_connect(f"mapi:monetdb://{self.hostname}/{self.database}", username=self.username, password=self.password)
+
+    def test_username_component(self):
+        try:
+            self.attempt_connect(f"mapi:monetdb://{self.hostname}:{self.port}/{self.database}", username="not" + self.username, password="not" + self.password)
+        except DatabaseError:
+            # expected to fail, username and password incorrect
+            pass
+        # override username and password parameters from within url
+        self.attempt_connect(f"mapi:monetdb://{self.username}:{self.password}@{self.hostname}:{self.port}/{self.database}", username="not" + self.username, password="not" + self.password)
+
+    def test_ipv4_address(self):
+        try:
+            # gethostbyname only resolves ipv4
+            ip = gethostbyname(self.hostname)
+        except Exception:
+            # can't test, return success
+            return
+        self.attempt_connect(f"mapi:monetdb://{ip}:{self.port}/{self.database}", username=self.username, password=self.password)
+
+    def test_unix_domain_socket(self):
+        sock_path = "/tmp/.s.monetdb.%i" % self.port
+        if not os.path.exists(sock_path):
+            return
+        uri = f"mapi:monetdb://{sock_path}?database={self.database}"
+        self.attempt_connect(uri, username=self.username, password=self.password)
+
+    def test_unix_domain_socket_username(self):
+        sock_path = "/tmp/.s.monetdb.%i" % self.port
+        if not os.path.exists(sock_path):
+            return
+        uri = f"mapi:monetdb://{self.username}:{self.password}@{sock_path}?database={self.database}"
+        self.attempt_connect(uri, username="not" + self.username, password="not" + self.password)

--- a/tests/test_mapi_uri.py
+++ b/tests/test_mapi_uri.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from pymonetdb import connect
 from tests.util import test_args
 
+
 class TestMapiUri(TestCase):
 
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,6 @@ deps=
     pytest
     six
     mock
-commands=py.test
+commands=py.test {posargs}
 
 passenv=MAPIPORT TSTHOSTNAME TSTPASSPHRASE TSTDB TSTUSERNAME TSTPASSWORD


### PR DESCRIPTION
Allow to connect using a full mapi uri in place of the database parameter.

TCP syntax: `mapi:monetdb://[<username>[:<password>]@]<host>[:<port>]/<database>`
Unix domain syntax: `mapi:monetdb:///[<username>[:<password>]@]path/to/socket?database=<database>`