### PR TITLE
Improve timezone handling

### DIFF
--- a/pymonetdb/sql/monetize.py
+++ b/pymonetdb/sql/monetize.py
@@ -46,11 +46,21 @@ def monet_bytes(data):
     return "'%s'" % data.hex()
 
 
+def _tzaware(time_or_datetime):
+    """
+    returns True if the time or datetime is timezone aware, False otherwise.
+    """
+    return time_or_datetime.utcoffset() is not None
+
+
 def monet_datetime(data):
     """
     returns a casted timestamp
     """
-    return "TIMESTAMP %s" % monet_escape(data)
+    if _tzaware(data):
+        return "TIMESTAMPTZ %s" % monet_escape(data)
+    else:
+        return "TIMESTAMP %s" % monet_escape(data)
 
 
 def monet_date(data):
@@ -64,7 +74,10 @@ def monet_time(data):
     """
     returns a casted time
     """
-    return "TIME %s" % monet_escape(data)
+    if _tzaware(data):
+        return "TIMETZ %s" % monet_escape(data)
+    else:
+        return "TIME %s" % monet_escape(data)
 
 
 def monet_timedelta(data):

--- a/pymonetdb/sql/pythonize.py
+++ b/pymonetdb/sql/pythonize.py
@@ -14,7 +14,7 @@ import datetime
 import re
 import uuid
 from decimal import Decimal
-from datetime import timedelta
+from datetime import timedelta, timezone
 
 from pymonetdb.sql import types
 from pymonetdb.exceptions import ProgrammingError
@@ -193,9 +193,23 @@ def TimeFromTicks(ticks):
     return Time(*time.localtime(ticks)[3:6])
 
 
+def TimeTzFromTicks(ticks):
+    """Convert ticks to python Time"""
+    return _make_localtime(Time(*time.localtime(ticks)[3:6]))
+
+
 def TimestampFromTicks(ticks):
     """Convert ticks to python Timestamp"""
     return Timestamp(*time.localtime(ticks)[:6])
+
+
+def TimestampTzFromTicks(ticks):
+    """Convert ticks to python Timestamp"""
+    return _make_localtime(Timestamp(*time.localtime(ticks)[:6]))
+
+
+def _make_localtime(t):
+    return t.replace(tzinfo=timezone(timedelta(hours=1)))
 
 
 Date = datetime.date

--- a/pymonetdb/sql/pythonize.py
+++ b/pymonetdb/sql/pythonize.py
@@ -30,8 +30,12 @@ def _extract_timezone(data):
     else:
         raise ProgrammingError("no + or - in %s" % data)
 
-    return data[:-6], datetime.timedelta(hours=sign * int(data[-5:-3]),
-                                         minutes=sign * int(data[-2:]))
+    hours = sign * int(data[-5:-3])
+    minutes = sign * int(data[-2:])
+    delta = timedelta(hours=hours, minutes=minutes)
+    timezone = datetime.timezone(delta)
+
+    return data[:-6], timezone
 
 
 def strip(data):
@@ -61,9 +65,9 @@ def py_timetz(data):
     """
     t, timezone_delta = _extract_timezone(data)
     if '.' in t:
-        return (datetime.datetime.strptime(t, '%H:%M:%S.%f') + timezone_delta).time()
+        return (datetime.datetime.strptime(t, '%H:%M:%S.%f').replace(tzinfo=timezone_delta)).time()
     else:
-        return (datetime.datetime.strptime(t, '%H:%M:%S') + timezone_delta).time()
+        return (datetime.datetime.strptime(t, '%H:%M:%S').replace(tzinfo=timezone_delta)).time()
 
 
 def py_date(data):
@@ -86,9 +90,9 @@ def py_timestamptz(data):
     """
     dt, timezone_delta = _extract_timezone(data)
     if '.' in dt:
-        return datetime.datetime.strptime(dt, '%Y-%m-%d %H:%M:%S.%f') + timezone_delta
+        return datetime.datetime.strptime(dt, '%Y-%m-%d %H:%M:%S.%f').replace(tzinfo=timezone_delta)
     else:
-        return datetime.datetime.strptime(dt, '%Y-%m-%d %H:%M:%S') + timezone_delta
+        return datetime.datetime.strptime(dt, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone_delta)
 
 
 def py_sec_interval(data: str) -> timedelta:

--- a/pymonetdb/sql/pythonize.py
+++ b/pymonetdb/sql/pythonize.py
@@ -65,9 +65,9 @@ def py_timetz(data):
     """
     t, timezone_delta = _extract_timezone(data)
     if '.' in t:
-        return (datetime.datetime.strptime(t, '%H:%M:%S.%f').replace(tzinfo=timezone_delta)).time()
+        return datetime.datetime.strptime(t, '%H:%M:%S.%f').time().replace(tzinfo=timezone_delta)
     else:
-        return (datetime.datetime.strptime(t, '%H:%M:%S').replace(tzinfo=timezone_delta)).time()
+        return datetime.datetime.strptime(t, '%H:%M:%S').time().replace(tzinfo=timezone_delta)
 
 
 def py_date(data):

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -236,7 +236,7 @@ class DatabaseTest(unittest.TestCase):
         ticks = time()
 
         def generator(row, col):
-            return pymonetdb.TimeFromTicks(ticks + row * 86400 - col * 1313)
+            return pymonetdb.TimeTzFromTicks(ticks + row * 86400 - col * 1313)
 
         self.check_data_integrity(
             ('col1 TIMETZ',),
@@ -266,7 +266,7 @@ class DatabaseTest(unittest.TestCase):
         ticks = time()
 
         def generator(row, col):
-            return pymonetdb.TimestampFromTicks(ticks + row * 86400 - col * 1313)
+            return pymonetdb.TimestampTzFromTicks(ticks + row * 86400 - col * 1313)
 
         self.check_data_integrity(
             ('col1 TIMESTAMPTZ',),

--- a/tests/test_monetize.py
+++ b/tests/test_monetize.py
@@ -29,6 +29,10 @@ class TestMonetize(unittest.TestCase):
         x = datetime.datetime(2017, 12, 6, 12, 30)
         self.assertEqual(convert(x), "TIMESTAMP '2017-12-06 12:30:00'")
 
+    def test_datetime_tz(self):
+        x = datetime.datetime(2017, 12, 6, 12, 30).replace(tzinfo=datetime.timezone(datetime.timedelta(hours=3)))
+        self.assertEqual(convert(x), "TIMESTAMPTZ '2017-12-06 12:30:00+03:00'")
+
     def test_date(self):
         x = datetime.date(2017, 12, 6)
         self.assertEqual(convert(x), "DATE '2017-12-06'")
@@ -36,6 +40,10 @@ class TestMonetize(unittest.TestCase):
     def test_time(self):
         x = datetime.time(12, 5)
         self.assertEqual(convert(x), "TIME '12:05:00'")
+
+    def test_time_tz(self):
+        x = datetime.time(12, 5).replace(tzinfo=datetime.timezone(datetime.timedelta(hours=3)))
+        self.assertEqual(convert(x), "TIMETZ '12:05:00+03:00'")
 
     def test_timedelta(self):
         x = datetime.timedelta(days=5, hours=2, minutes=10)


### PR DESCRIPTION
If a datetime has a timezone, use TIMESTAMPTZ 'bla' instead of TIMESTAMP 'bla'. Conversely, when creating a datetime from an incoming value that has a time zone indicator, do not add it to the datetime but store it in its .tzinfo field.

This ensures that both naive and aware datetimes can safely roundtrip to and from the server, and that `SELECT now()` yields the expected value.

To make this work we have to set the session timezone at connect time. Most other language bindings already did this.