### PR TITLE
add test to try insert binary data

### DIFF
--- a/tests/test_pythonize.py
+++ b/tests/test_pythonize.py
@@ -65,3 +65,10 @@ class TestPythonize(unittest.TestCase):
 
         self.assertEqual(row[0].isoformat(), dt.isoformat())
         self.assertEqual(row[1].isoformat(), dtz.isoformat())
+
+    def test_insert_binary_data(self):
+        self.cursor.execute('CREATE TEMPORARY TABLE binary_foo (i BLOB)')
+        self.cursor.execute('INSERT INTO binary_foo VALUES ' + b"i_am_binary_data")
+
+        row = self.cursor.fetchone()
+        self.assertTrue(row[0] is not None)


### PR DESCRIPTION
Trying to insert binary data into a blob field now fails. This PR adds a test for that.