### PR TITLE
Perform bin<->hex conversion directly, not in pymonetdb.Binary

### DIFF
--- a/pymonetdb/sql/monetize.py
+++ b/pymonetdb/sql/monetize.py
@@ -44,7 +44,7 @@ def monet_bytes(data):
     """
     converts bytes to string
     """
-    return "'%s'" % data.hex()
+    return "BLOB '%s'" % data.hex()
 
 
 def _tzaware(time_or_datetime):

--- a/pymonetdb/sql/pythonize.py
+++ b/pymonetdb/sql/pythonize.py
@@ -109,9 +109,9 @@ def py_day_interval(data: str) -> int:
     return timedelta(seconds=int(Decimal(data))).days
 
 
-def py_bytes(data):
+def py_bytes(data: str):
     """Returns a bytes (py3) or string (py2) object representing the input blob."""
-    return Binary(data)
+    return bytes.fromhex(data)
 
 
 def oid(data):
@@ -179,9 +179,9 @@ def convert(data, type_code):
 # below stuff required by the DBAPI
 
 def Binary(data):
-    """returns binary encoding of data"""
-    return bytes.fromhex(data)
-
+    """Convert to wraps binary data"""
+    assert isinstance(data, bytes) or isinstance(data, bytearray)
+    return data
 
 def DateFromTicks(ticks):
     """Convert ticks to python Date"""

--- a/tests/test_dbapi2.py
+++ b/tests/test_dbapi2.py
@@ -710,8 +710,9 @@ class DatabaseAPI20Test(unittest.TestCase):
         self.assertEqual(str(t1), str(t2))
 
     def test_Binary(self):
-        b = pymonetdb.Binary('1234567890ABCDEF')
-        b = pymonetdb.Binary('')
+        b1 = b'\x00\x01\x02\x03'
+        b2 = pymonetdb.Binary(b1)
+        self.assertEqual(b1, b2)
 
     def test_STRING(self):
         self.assertTrue(hasattr(pymonetdb, 'STRING'), 'module.STRING must be defined')


### PR DESCRIPTION
When encoding, encode bytes values as BLOB 'hexbytes', not just 'hexbytes'.
When decoding, call fromhex directly instead of going through pymonetdb.Binary.

pymonetdb.Binary() tried to hexdecode its argument, this has now been removed.
If I understand PEP249 correctly, pymonetdb.Binary is intended for
application code to portably mark data as Binary. This was necessary
in Python 2 where strings and byte arrays shared the same underlying type.

For example, SQLAlchemy calls pymonetdb.Binary() on bytes objects,
with the old implementation this used to  crash.