### PR TITLE
COPY INTO FROM ON CLIENT

### DIFF
--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -534,7 +534,7 @@ class Upload:
         self.error = False
         self.cancelled = False
         self.bytes_sent = 0
-        self.chunk_size = 1024 * 1024
+        self.chunk_size = 100 # 1024 * 1024
         self.chunk_left = self.chunk_size
         self.writer = None
         self.twriter = None
@@ -639,6 +639,8 @@ class UploadIO(BufferedIOBase):
         return True
 
     def write(self, b):
+        if self.upload.is_cancelled():
+            return 0
         n = len(b)
         self.upload._send_data(b)
         return n

--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -390,7 +390,7 @@ class Connection(object):
 
     def _handle_transfer(self, cmd: str):
         if cmd.startswith("r "):
-            parts = cmd[2:].split(' ', 2)
+            parts = cmd[2:-1].split(' ', 2)
             if len(parts) == 2:
                 try:
                     n = int(parts[0])

--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -595,15 +595,17 @@ class Upload:
         if self.error:
             return
         if self.mapi:
+            server_wants_more = False
             if self.chunk_left != self.chunk_size:
                 # finish the current block
-                self._send_and_get_prompt(b'')
-            # send empty block to indicate end of upload
-            self.mapi._putblock('')
-            # receive acknowledgement
-            resp = self.mapi._getblock()
-            if resp != MSG_FILETRANS:
-                raise ProgrammingError(f"Unexpected server response: {resp[:50]!r}")
+                server_wants_more = self._send_and_get_prompt(b'')
+            if server_wants_more:
+                # send empty block to indicate end of upload
+                self.mapi._putblock('')
+                # receive acknowledgement
+                resp = self.mapi._getblock()
+                if resp != MSG_FILETRANS:
+                    raise ProgrammingError(f"Unexpected server response: {resp[:50]!r}")
             self.mapi = None
 
 

--- a/pymonetdb/mapi.py
+++ b/pymonetdb/mapi.py
@@ -336,6 +336,7 @@ class Connection(object):
         response = ":".join(["BIG", self.username, pwhash, self.language, self.database]) + ":"
 
         if len(challenges) >= 7:
+            response += "FILETRANS:"
             options_level = 0
             for part in challenges[6].split(","):
                 if part.startswith("sql="):

--- a/pymonetdb/sql/connections.py
+++ b/pymonetdb/sql/connections.py
@@ -126,6 +126,9 @@ class Connection:
         c.execute(cmd)
         c.close()
 
+    def set_uploader(self, uploader):
+        self.mapi.set_uploader(uploader)
+
     def commit(self):
         """
         Commit any pending transaction to the database. Note that


### PR DESCRIPTION
This work is not finished but I'm creating the pull request so you can keep an eye on it and make suggestions, and also to benefit from the CI. The idea is to add support for ON CLIENT. For example:
```
COPY INTO mytable FROM 'data.csv' ON CLIENT;
```
With ON CLIENT, the server does not open the the file by itself but sends a request to pymonetdb to open it on its behalf. The client opens the file and reads it, or makes up some data on the spot, and sends it to the server which processes it as usual.

ON CLIENT is useful to avoid having to first copy data to a location on the server accessible both to the user and the server, and for side stepping all sorts of permissions problems. Mclient has supported it for quite a while and recently I added support to monetdb-jdbc. Now I would like to add support for it to pymonetdb.