### PR TITLE
Fix udf debugging and remove an annoying tox warning

### DIFF
--- a/pymonetdb/sql/debug.py
+++ b/pymonetdb/sql/debug.py
@@ -2,7 +2,6 @@ import pickle
 import tempfile
 import re
 import pdb
-from past.builtins import execfile  # type: ignore
 from typing import Any, TYPE_CHECKING
 
 
@@ -102,7 +101,8 @@ def debug(cursor, query, fname, sample=-1):
             arglist, fcode.replace("\n", "\n "))
         f.write(function_definition.encode('utf-8'))
         f.flush()
-        execfile(f.name, globals(), locals())
+        compiled = compile(function_definition, f.name, 'exec')
+        exec(compiled, globals(), locals())
 
         cleaned_arguments['_conn'] = LoopbackObject(cursor)
         pdb.set_trace()

--- a/pymonetdb/sql/debug.py
+++ b/pymonetdb/sql/debug.py
@@ -27,7 +27,7 @@ class LoopbackObject(object):
                       del dd['_conn']
                       del dd['_columns']
                       del dd['_column_types']
-                      return pickle.dumps(dd);
+                      return pickle.dumps(dd).hex();
                   };""")
         self.__conn.execute("""
                   SELECT *
@@ -135,7 +135,7 @@ def exportparameters(cursor, ftype, fname, query, quantity_parameters, sample):
                 args, _, _, values = inspect.getargvalues(frame);
                 dd = {x: values[x] for x in args};
                 del dd['_conn']
-                return pickle.dumps(dd);
+                return pickle.dumps(dd).hex();
             };""" % return_type
     else:
         export_function = """
@@ -162,7 +162,7 @@ def exportparameters(cursor, ftype, fname, query, quantity_parameters, sample):
                 dd[argname] = aux
                 print(dd[argname])
             print(x)
-            return pickle.dumps(dd);
+            return pickle.dumps(dd).hex();
             };
             """ % (return_type, str(sample))
 
@@ -179,7 +179,8 @@ def exportparameters(cursor, ftype, fname, query, quantity_parameters, sample):
     if len(input_data) <= 0:
         raise Exception("Could not load input data!")
 
-    arguments = pickle.loads(input_data[0][0])
+    bin_data = bytes.fromhex(input_data[0][0])
+    arguments = pickle.loads(bin_data)
 
     if len(arguments) != quantity_parameters + 2:
         raise Exception("Incorrect amount of input arguments found!")

--- a/tests/test_udf.py
+++ b/tests/test_udf.py
@@ -28,7 +28,6 @@ class TestUdf(TestCase):
         if cls.conn:
             cls.conn.close()
 
-    @skip("Disabled, see issue #49")
     def test_debug_udf(self):
         self.cursor.execute("""
             CREATE FUNCTION test_python_udf(i INTEGER)


### PR DESCRIPTION
Fix issue #49. The problem was that as of Python3, pickle no longer returns strings but bytes objects. First I attempted to let the `export_parameters` function return a BLOB but that didn't work so in the mean time it returns a hex encoding of the bytes.

With this issue fixed I could test my fix for the deprecation warning that shows up in the tox output:
```
=============================== warnings summary ===============================
.tox/py310/lib/python3.10/site-packages/past/builtins/misc.py:45
  /home/jvr/src/pymonetdb/.tox/py310/lib/python3.10/site-packages/past/builtins/misc.py:45: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    from imp import reload
```